### PR TITLE
docs: add Node.js 22 to AWS Lambda supported runtimes (#572)

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ This plugin will automatically set the esbuild `target` for the following suppor
 
 | Runtime      | Target   |
 | ------------ | -------- |
+| `nodejs22.x` | `node22` |
 | `nodejs20.x` | `node20` |
 | `nodejs18.x` | `node18` |
 | `nodejs16.x` | `node16` |


### PR DESCRIPTION
fix: https://github.com/floydspace/serverless-esbuild/issues/561